### PR TITLE
Update API URL for Namesilo

### DIFF
--- a/bb-library/Registrar/Adapter/Namesilo.php
+++ b/bb-library/Registrar/Adapter/Namesilo.php
@@ -316,6 +316,6 @@ class Registrar_Adapter_Namesilo extends Registrar_AdapterAbstract
     {
         if ($this->isTestEnv())
             return 'http://sandbox.namesilo.com/api/';
-        return 'http://namesilo.com/api/';
+        return 'https://namesilo.com/api/';
     }
 }


### PR DESCRIPTION
Changed URL line 319 from "http://namesilo.com/api/" to "https://namesilo.com/api/" to fix "Not Use HTTPS" error.