### PR TITLE
Update Namesilo.php

### DIFF
--- a/bb-library/Registrar/Adapter/Namesilo.php
+++ b/bb-library/Registrar/Adapter/Namesilo.php
@@ -26,8 +26,6 @@ class Registrar_Adapter_Namesilo extends Registrar_AdapterAbstract
         if(isset($options['Payment_ID']) && !empty($options['Payment_ID'])) {
             $this->config['Payment_ID'] = $options['Payment_ID'];
             unset($options['Payment_ID']);
-        } else {
-            throw new Registrar_Exception('Domain registrar "Namesilo" is not configured preoprly. Please update configuration paramer Payment ID".');
         }
     }
     public static function getConfig()


### PR DESCRIPTION
I removed throwing exception when someone is not using Payment ID, this prevented them from using module without Payment ID defined.
But there is an issue, this is how input box is showing. 

`<input id="el-Payment_ID" type="Payment_ID" name="config[Payment_ID]" value="" required="required">`

It is set to REQUIRED and I have no idea how do i change that... I'm going to contact boxbilling musicboxlimited for this and i'm gonna do another pull request.
So basically, once you define Payment ID only way to remove it is to inspect element and remove `required="required"` and then save it.