### PR TITLE
Update API endpoint for MaxMind web services

### DIFF
--- a/bb-library/Hook/MaxMind.php
+++ b/bb-library/Hook/MaxMind.php
@@ -90,7 +90,7 @@ throw new Payment_Exception('The Zip/Postcode that you have entered does not exi
 
 else {
 
-        $url='https://minfraud2.maxmind.com/app/ccv2r?'.http_build_query($rp);
+        $url='https://minfraud.maxmind.com/app/ccv2r?'.http_build_query($rp);
         $content = file_get_contents($url);
 
         // enable this to debug response to the screen when clicking checkout button


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)